### PR TITLE
chore: update immich helm chart to 0.13.1

### DIFF
--- a/gitops/apps/immich/helmrelease.yaml
+++ b/gitops/apps/immich/helmrelease.yaml
@@ -8,7 +8,7 @@ spec:
   chart:
     spec:
       chart: immich
-      version: 0.12.0
+      version: 0.13.1
       sourceRef:
         kind: HelmRepository
         name: immich
@@ -36,18 +36,7 @@ spec:
               tag: v3.0.2
     immich:
       metrics:
-        enable: false
-      probes:
-        liveness:
-          spec:
-            initialDelaySeconds: 3600
-        readiness:
-          spec:
-            initialDelaySeconds: 3600
-        startup:
-          spec:
-            failureThreshold: 1000
-            periodSeconds: 10
+        enabled: false
       persistence:
         library:
           existingClaim: immich-data
@@ -55,8 +44,11 @@ spec:
     server:
       enabled: true
       controllers:
-        strategy: Recreate
         main:
+          strategy: Recreate
+          serviceAccount:
+            create: true
+            name: 'immich'
           containers:
             main:
               resources:
@@ -67,9 +59,6 @@ spec:
                   gpu.intel.com/i915: 1
                   cpu: 2
                   memory: 4Gi
-              serviceAccount:
-                create: true
-                name: 'immich'
       automountServiceAccountToken: true
       ingress:
         main:
@@ -79,11 +68,9 @@ spec:
       persistence:
         cache:
           enabled: true
-          size: 10Gi
-          # Optional: Set this to pvc to avoid downloading the ML models every start.
+          # Optional: switch type to persistentVolumeClaim (and add size/accessMode/storageClass
+          # under it) to avoid re-downloading the ML models on every start.
           type: emptyDir
-          accessMode: ReadWriteOnce
-          storageClass: disk
       controllers:
         main:
           containers:

--- a/gitops/apps/immich/helmrepo.yaml
+++ b/gitops/apps/immich/helmrepo.yaml
@@ -5,4 +5,5 @@ metadata:
   namespace: immich
 spec:
   interval: 24h
-  url: https://immich-app.github.io/immich-charts
+  type: oci
+  url: oci://ghcr.io/immich-app/immich-charts


### PR DESCRIPTION
## Contexte

Le chart immich publié via l'index HTTP (immich-app.github.io/immich-charts) est gelé à 0.12.0. Les mainteneurs publient désormais le chart via OCI (ghcr.io/immich-app/immich-charts), dernière version 0.13.1.

## Changements

**helmrepo.yaml** — bascule source HTTP (figée) → OCI :
- `type: oci` + `url: oci://ghcr.io/immich-app/immich-charts`

**helmrelease.yaml** — bump 0.12.0 → 0.13.1 + conformité au nouveau values.schema.json strict (breaking change 0.13.0, #382) :
- `immich.metrics.enable` → `enabled` (typo, était ignorée)
- `server` : `strategy` et `serviceAccount` déplacés au niveau contrôleur (étaient ignorés)
- suppression du bloc `immich.probes` (placement invalide, jamais appliqué)
- suppression de `size`/`accessMode`/`storageClass` sous le cache emptyDir du ML (invalides)

Image toujours surchargée en v3.0.2 (updatecli), au lieu du défaut v3.0.0 du chart.

## Validation
`helm template` contre 0.13.1 passe (exit 0, schéma strict OK).

## À noter (comportement)
Deux réglages autrefois inactifs deviennent actifs : serveur en stratégie `Recreate`, et ServiceAccount `immich` créée/utilisée par le contrôleur serveur. Les longs délais de probes n'ont jamais été appliqués et ne sont pas réintroduits (probes par défaut du chart conservées).