### PR TITLE
fix(immich): remove broken serviceAccount override on server controller

### DIFF
--- a/gitops/apps/immich/helmrelease.yaml
+++ b/gitops/apps/immich/helmrelease.yaml
@@ -46,9 +46,8 @@ spec:
       controllers:
         main:
           strategy: Recreate
-          serviceAccount:
-            create: true
-            name: 'immich'
+          # No serviceAccount override: use the chart's auto-created "immich-server" SA.
+          # (Pinning name: immich referenced a non-existent SA and blocked pod creation.)
           containers:
             main:
               resources:


### PR DESCRIPTION
The 0.13.1 migration pinned serviceAccount.name: immich on the server controller, but the chart creates the SA as immich-server. The pod referenced a non-existent SA 'immich', so the API refused pod creation; combined with strategy: Recreate this took the immich-server deployment to 0 available (production outage).

Drop the override so the server uses the chart's auto-created immich-server SA (the pre-migration working behavior).