### PR TITLE
fix(nextcloud): dedupe NEXTCLOUD_TRUSTED_DOMAINS to unblock upgrade

### DIFF
--- a/gitops/apps/nextcloud/helm.yml
+++ b/gitops/apps/nextcloud/helm.yml
@@ -97,6 +97,13 @@ spec:
       protocol: https
     nextcloud:
       host: nimbus.bealv.io
+      # Set via the chart's native value (single NEXTCLOUD_TRUSTED_DOMAINS env).
+      # Previously also set through extraEnv, producing a duplicate env var that
+      # broke the strategic-merge-patch on upgrade.
+      trustedDomains:
+        - nimbus.bealv.io
+        - 192.168.0.0/16
+        - 10.0.0.0/8
       existingSecret:
         enabled: true
         secretName: nextcloud-secrets
@@ -126,8 +133,6 @@ spec:
       extraEnv:
         - name: TRUSTED_PROXIES
           value: '10.0.1.204 10.0.1.205 192.168.1.200 192.168.1.201'
-        - name: NEXTCLOUD_TRUSTED_DOMAINS
-          value: '192.168.0.0/16 10.0.0.0/8'
         - name: OC_MAINTENANCE_WINDOW_START
           value: '1'
         - name: OVERWRITEPROTOCOL


### PR DESCRIPTION
The chart emits NEXTCLOUD_TRUSTED_DOMAINS from nextcloud.host, and the same var was also set via extraEnv. The duplicate env var broke the Deployment strategic-merge-patch on upgrade to 8.9.1 ($setElementOrder mismatch), stalling the HelmRelease (old v31 pod kept running, no outage).

Move trusted domains to the chart-native nextcloud.trustedDomains list (host + internal ranges) and drop the extraEnv duplicate.